### PR TITLE
Scalable AnyCable

### DIFF
--- a/config/anycable_nginx.conf
+++ b/config/anycable_nginx.conf
@@ -1,0 +1,16 @@
+upstream grpcservers {
+    server anycable-rpc-one:50051;
+    server anycable-rpc-two:50051;
+}
+
+server {
+    listen 50051 http2;
+    server_name localhost;
+
+    access_log /var/log/nginx/grpc_log.json;
+    error_log /var/log/nginx/grpc_error_log.json debug;
+
+    location / {
+        grpc_pass grpc://grpcservers;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,23 @@ services:
       - redis
 
   anycable-rpc:
+    image: nginx:1.17.3-alpine
+    volumes:
+      - ./log:/var/log/nginx
+      - ./config/anycable_nginx.conf:/etc/nginx/conf.d/anycable.conf
+    ports:
+      - '50051'
+    depends_on:
+      - anycable-rpc-one
+      - anycable-rpc-two
+
+  anycable-rpc-one:
+    <<: *backend
+    command: bundle exec anycable
+    ports:
+      - '50051'
+
+  anycable-rpc-two:
     <<: *backend
     command: bundle exec anycable
     ports:


### PR DESCRIPTION
# Context

Added Docker configuration to run AnyCable gRCP servers behind Nginx proxy.
This PR tries to reproduce [that issue](https://github.com/anycable/anycable-go/issues/79).
After several attempts, I couldn't break the system noticed in the issue.